### PR TITLE
fix: Unicode character boundary panics issue

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -170,9 +170,10 @@ fn read_readme(root_path: &Path) -> Option<String> {
 }
 
 fn truncate_string(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
+    if s.chars().count() <= max_len {
         s.to_string()
     } else {
-        format!("{}...", &s[..max_len - 3])
+        let truncated: String = s.chars().take(max_len.saturating_sub(3)).collect();
+        format!("{}...", truncated)
     }
 }


### PR DESCRIPTION
## Issue
The application was experiencing panics when processing text containing multi-byte UTF-8 characters (Japanese, Korean, Chinese, emojis, etc.). The error occurred due to unsafe string slicing at byte positions that split multi-byte Unicode characters.

<img width="632" height="69" alt="スクリーンショット 2025-08-13 9 52 00" src="https://github.com/user-attachments/assets/bbb36a45-7ff8-4380-9353-30caa0f50544" />

## Root Cause
Two functions were using byte-based string slicing instead of character-aware truncation:
1. `truncate_string()` in `src/context.rs` - Used `&s[..max_len - 3]` 

## Solution
### Fixed `truncate_string()` function:
- **Before**: `&s[..max_len - 3]` (byte-based slicing - unsafe)
- **After**: `s.chars().take(max_len - 3).collect()` (character-aware truncation)
