### PR TITLE
fix: Update git submodule configuration and workflow initialization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,9 @@ jobs:
     steps:
     - name: Checkout code 📦
       uses: actions/checkout@v4
-    
+      with:
+        submodules: 'recursive'
+
     - name: Install dependencies 🛠️
       run: |
         sudo apt-get update
@@ -232,7 +234,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    
+        submodules: 'recursive'
+
     - name: Download artifacts 📥
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,9 @@ jobs:
     steps:
     - name: Checkout code 📦
       uses: actions/checkout@v4
-    
+      with:
+        submodules: 'recursive'
+
     - name: Install Rust 🦀
       uses: dtolnay/rust-toolchain@stable
       with:
@@ -57,7 +59,9 @@ jobs:
     steps:
     - name: Checkout code 📦
       uses: actions/checkout@v4
-    
+      with:
+        submodules: 'recursive'
+
     - name: Install Rust 🦀
       uses: dtolnay/rust-toolchain@stable
       with:
@@ -79,9 +83,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-index-
 
-    - name: Initialize submodules
-      run: git submodule update --init --recursive
-    
     - name: Cache cargo build 🏗️
       uses: actions/cache@v4
       with:
@@ -167,10 +168,12 @@ jobs:
     steps:
     - name: Checkout code 📦
       uses: actions/checkout@v4
-    
+      with:
+        submodules: 'recursive'
+
     - name: Install Rust 🦀
       uses: dtolnay/rust-toolchain@stable
-    
+
     - name: Install cargo-audit 🔍
       run: cargo install cargo-audit
     

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/8b-is/marqant.git
 [submodule "codexist"]
 	path = codexist
-	url = git@github.com:8b-is/codexist
+	url = https://github.com/8b-is/codexist.git


### PR DESCRIPTION
Changes:
- Convert codexist submodule from SSH to HTTPS URL
  - Was: git@github.com:8b-is/codexist
  - Now: https://github.com/8b-is/codexist.git
  - Fixes: SSH authentication failures in CI environments

- Update all GitHub workflow checkout actions to use submodules: 'recursive'
  - rust.yml: Added to check, build, and security jobs
  - release.yml: Added to build-dxt and release jobs
  - Removed redundant 'git submodule update' step

This ensures:
✅ Submodules work in CI/CD without SSH keys
✅ Consistent submodule initialization across all workflows ✅ Both marqant and codexist submodules properly initialized ✅ Cleaner workflow configuration using checkout@v4 features

Resolves submodule initialization failures in automated environments.