### PR TITLE
Update for cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,9 @@ jobs:
     steps:
     - name: Checkout code 📦
       uses: actions/checkout@v4
-    
+      with:
+        submodules: 'recursive'
+
     - name: Install dependencies 🛠️
       run: |
         sudo apt-get update
@@ -232,7 +234,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    
+        submodules: 'recursive'
+
     - name: Download artifacts 📥
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,9 @@ jobs:
     steps:
     - name: Checkout code 📦
       uses: actions/checkout@v4
-    
+      with:
+        submodules: 'recursive'
+
     - name: Install Rust 🦀
       uses: dtolnay/rust-toolchain@stable
       with:
@@ -57,7 +59,9 @@ jobs:
     steps:
     - name: Checkout code 📦
       uses: actions/checkout@v4
-    
+      with:
+        submodules: 'recursive'
+
     - name: Install Rust 🦀
       uses: dtolnay/rust-toolchain@stable
       with:
@@ -79,9 +83,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-index-
 
-    - name: Initialize submodules
-      run: git submodule update --init --recursive
-    
     - name: Cache cargo build 🏗️
       uses: actions/cache@v4
       with:
@@ -167,10 +168,12 @@ jobs:
     steps:
     - name: Checkout code 📦
       uses: actions/checkout@v4
-    
+      with:
+        submodules: 'recursive'
+
     - name: Install Rust 🦀
       uses: dtolnay/rust-toolchain@stable
-    
+
     - name: Install cargo-audit 🔍
       run: cargo install cargo-audit
     

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/8b-is/marqant.git
 [submodule "codexist"]
 	path = codexist
-	url = git@github.com:8b-is/codexist
+	url = https://github.com/8b-is/codexist.git


### PR DESCRIPTION
This pull request updates how git submodules are handled in the CI workflows and corrects a submodule URL to use HTTPS. The most significant changes are the automation of submodule initialization during the code checkout step in GitHub Actions, which simplifies workflow configuration and improves reliability.

**CI workflow improvements:**

* Added `submodules: 'recursive'` to the `actions/checkout@v4` step in `.github/workflows/release.yml` and `.github/workflows/rust.yml` to automatically initialize and update submodules during checkout, removing the need for manual submodule commands. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R189-R190) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R237) [[3]](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dR28-R29) [[4]](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dR62-R63) [[5]](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dR171-R172)
* Removed the manual `git submodule update --init --recursive` step from `.github/workflows/rust.yml`, since submodules are now handled by the checkout action.

**Repository configuration:**

* Updated the `codexist` submodule URL in `.gitmodules` to use HTTPS instead of SSH, making it easier for CI and contributors without SSH keys to clone the repository.